### PR TITLE
Fix time flicker

### DIFF
--- a/server/app/app.py
+++ b/server/app/app.py
@@ -12,7 +12,7 @@ app.config.update({
 })
 if 'FLASK_SETTINGS' in os.environ:
     app.config.from_envvar('FLASK_SETTINGS')
-mongo = PyMongo(app)
+mongo = PyMongo(app, tz_aware=True)
 
 _static_cache = {}
 @app.template_filter('cachebust')

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -12,7 +12,7 @@ def _json_unknown(obj):
     elif isinstance(obj, pymongo.cursor.Cursor):
         return list(obj)
     elif isinstance(obj, datetime):
-        return time.mktime(obj.timetuple())
+        return obj.timestamp()
     raise TypeError(type(object))
 
 def json_encode(j):

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -12,7 +12,7 @@ def _json_unknown(obj):
     elif isinstance(obj, pymongo.cursor.Cursor):
         return list(obj)
     elif isinstance(obj, datetime):
-        return obj.timestamp()
+        return int(obj.timestamp())
     raise TypeError(type(object))
 
 def json_encode(j):

--- a/server/app/views.py
+++ b/server/app/views.py
@@ -50,7 +50,7 @@ def get_feed(feed_id):
 def get_feed_text(feed_id):
     since = None
     if 'since' in request.args:
-        since = datetime.utcfromtimestamp(int(request.args['since']))
+        since = datetime.utcfromtimestamp(float(request.args['since']))
     limit = min(200, int(request.args.get('limit', 200)))
     calls = _get_feed(feed_id, since=since, limit=limit)
     return json_response(calls)

--- a/server/templates/feed.html
+++ b/server/templates/feed.html
@@ -33,7 +33,7 @@
       {% for c in calls %}
         <li class="call" id="call-{{ c['_id'] }}" data-id="{{ c['_id'] }} ">
             <div class="buttons button toggle">🔊</div>
-            <time>{{ c['ts'].strftime('%-m/%d/%Y, %H:%M:%S') }}</time>
+            <time>{{ c['ts'].strftime('%-m/%-d/%Y, %H:%M:%S') }}</time>
             {# <span class="audio"><audio controls src="{{ c.audio_url }}" preload="none"></audio></span> #}
             <span class="message" data-id="{{ c['transcriptions'][0]['_id'] }}">
                 {{ c['transcriptions'][0]['text'] }}


### PR DESCRIPTION
1. Fix day of month flicker by standardizing on non-zero-padded values.  Hours are still zero padded though.  :shrug:
2. Fix hours flickering due to timezone related brokenness.  (We were reinterpreting UTC times as local times when generating JSON.)