### PR TITLE
fix: stably sort transcriptions

### DIFF
--- a/server/static/app.js
+++ b/server/static/app.js
@@ -225,7 +225,12 @@ function handleLogEntry(obj, userText) {
   }
   calls[obj._id] = obj
   obj.transcriptions.sort(function(a, b) {
-    return (b.upvotes - b.downvotes) > (a.upvotes - a.downvotes)
+    const diff = (b.upvotes - b.downvotes) - (a.upvotes - a.downvotes)
+    if (diff == 0) {
+      if (a._id < b._id) { return -1 }
+      return 1
+    }
+    return diff
   })
   const existing = $(`#call-${obj._id}`)
   if (existing.length) {


### PR DESCRIPTION
These get sorted by total vote count, then by ID as a tiebreaker, with
the earliest transcription at any given vote count appearing first in
the list.

(We don't handle the case where multiple transcriptions have the same
ID, but neither does MongoDB.)