### PR TITLE
allow multi-line input for transcriptions

### DIFF
--- a/server/static/app.css
+++ b/server/static/app.css
@@ -45,9 +45,11 @@ h3, h4 {
   max-width: 100ex;
 }
 
-input[type=text] {
+textarea {
   margin-left: 1ex;
   flex-grow: 1;
+  font-family: serif;
+  resize: none;
 }
 
 form {

--- a/server/static/app.js
+++ b/server/static/app.js
@@ -135,6 +135,15 @@ function handleTranscriptionInput(evt) {
   saveButton.attr('disabled', isDuplicate)
 }
 
+function handleTranscriptionInputKeydown(evt) {
+  if (evt.which === 13) {
+    // The user pressed enter, treat this as a submission and don't pass the
+    // newline through.
+    if (evt.preventDefault) { evt.preventDefault() }
+    $(evt.target).parent().submit()
+  }
+}
+
 function handleCustomTranscription(evt) {
   if (evt.preventDefault) { evt.preventDefault() }
   $(evt.target).find('button').attr('disabled', true) // prevent repeat submission
@@ -188,6 +197,10 @@ function createLogEntry(obj) {
     const customEntry = $('<textarea wrap="soft" rows="2" />')
     customEntry.text(obj.transcriptions[0].text)
     customEntry.on('input', handleTranscriptionInput)
+    // We use keyup (exclusively) to catch pressing enter. We can't use it for
+    // our general input handler because that wouldn't catch certain mouse
+    // actions, etc.
+    customEntry.on('keydown', handleTranscriptionInputKeydown)
     customForm.append($('<button disabled submit>Save</button>'))
     customForm.append(customEntry)
     customTranscription.append(customForm)

--- a/server/static/app.js
+++ b/server/static/app.js
@@ -118,6 +118,7 @@ function handleVote(evt) {
 function handleTranscriptionInput(evt) {
   const newTranscription = $(evt.target).val()
   const saveButton = $(evt.target).parent().find('button')
+  evt.target.style.height = evt.target.scrollHeight + 'px'
 
   if (newTranscription.length < 3) {
     saveButton.attr('disabled', true)
@@ -138,7 +139,7 @@ function handleCustomTranscription(evt) {
   if (evt.preventDefault) { evt.preventDefault() }
   $(evt.target).find('button').attr('disabled', true) // prevent repeat submission
   const callId = getCallFromElement(evt.target)
-  const newTranscription = $(evt.target).find('input').val()
+  const newTranscription = $(evt.target).find('textarea').val()
 
   var fixes = parseInt(localStorage.getItem('fixes')) || 0;
   window.localStorage.setItem('fixes', ++fixes);
@@ -184,8 +185,8 @@ function createLogEntry(obj) {
     // The manual transcription entry form
     const customTranscription = $('<div class="custom-entry" />')
     const customForm = $('<form />')
-    const customEntry = $('<input type="text" />')
-    customEntry.attr('value', obj.transcriptions[0].text)
+    const customEntry = $('<textarea wrap="soft" rows="2" />')
+    customEntry.text(obj.transcriptions[0].text)
     customEntry.on('input', handleTranscriptionInput)
     customForm.append($('<button disabled submit>Save</button>'))
     customForm.append(customEntry)

--- a/server/static/app.js
+++ b/server/static/app.js
@@ -125,12 +125,12 @@ function handleTranscriptionInput(evt) {
     return
   }
 
-  const existingTranscriptions = $(evt.target)
-    .parents('.transcriptions')
-    .find('.transcription-text')
-    .map( function() { return this.textContent} )
-    .get()
-  const isDuplicate = existingTranscriptions.includes(newTranscription)
+  const callId = getCallFromElement(evt.target)
+  const isDuplicate = calls[callId]
+    .transcriptions
+    .some(function(transcription) {
+      return transcription.text === newTranscription
+    })
 
   saveButton.attr('disabled', isDuplicate)
 }


### PR DESCRIPTION
This defaults to two(+0.5ish, thanks browsers) lines of text, and
automatically increases the size of the textarea as more text gets
entered.

It doesn't automatically set the "correct" height of the entry form
because that would require it to run a layout first, which seems
impractical at the moment. The height will correct as soon as any text
change is made if it should be higher.